### PR TITLE
Add proxy helpers for Podman

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ cosign.key
 _build_*
 output
 _build-*/**
+cache/https-proxy-ca.pem

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Once you have the repository on your local drive, proceed to the next step.
 
 ## Step 2: Initial Setup
 
+### Working Behind an HTTPS Proxy
+
+If your environment exports `https_proxy`, run `just proxy-cert` before building. The helper captures the proxy's TLS certificate into `cache/https-proxy-ca.pem`; mount that file into your podman runs at `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` and `/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt`.
+
 ### Step 2a: Creating a Cosign Key
 
 Container signing is important for end-user security and is enabled on all Universal Blue images. By default the image builds *will fail* if you don't.

--- a/scripts/podman-proxy-flags.sh
+++ b/scripts/podman-proxy-flags.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Emit podman flags/env vars for proxy-aware builds. Prints nothing when no proxy is configured.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+raw_http_proxy="${http_proxy:-${HTTP_PROXY:-}}"
+raw_https_proxy="${https_proxy:-${HTTPS_PROXY:-}}"
+raw_no_proxy="${no_proxy:-${NO_PROXY:-}}"
+
+sanitize_proxy() {
+    local value="${1:-}"
+    [[ -z "${value}" ]] && return 0
+
+    local scheme="" remainder="${value}" credentials="" host="" port=""
+
+    if [[ "${remainder}" == *"://"* ]]; then
+        scheme="${remainder%%://*}"
+        remainder="${remainder#*://}"
+    fi
+
+    if [[ "${remainder}" == *"@"* ]]; then
+        credentials="${remainder%%@*}"
+        remainder="${remainder#*@}"
+    fi
+
+    remainder="${remainder%%/*}"
+
+    host="${remainder%%:*}"
+    port="${remainder#*:}"
+    if [[ "${port}" == "${host}" ]]; then
+        port=""
+    fi
+
+    if [[ -z "${port}" ]]; then
+        if [[ "${scheme}" == "https" || "${scheme}" == "HTTPS" ]]; then
+            port="443"
+        else
+            port="3128"
+        fi
+    fi
+
+    if [[ "${host}" == "127.0.0.1" || "${host}" == "localhost" || "${host}" == "0.0.0.0" ]]; then
+        host="host.containers.internal"
+    fi
+
+    local rebuilt=""
+    if [[ -n "${scheme}" ]]; then
+        rebuilt+="${scheme}://"
+    fi
+    if [[ -n "${credentials}" ]]; then
+        rebuilt+="${credentials}@"
+    fi
+    rebuilt+="${host}"
+    if [[ -n "${port}" ]]; then
+        rebuilt+=":${port}"
+    fi
+
+    printf '%s' "${rebuilt}"
+}
+
+augment_no_proxy() {
+    local value="${1:-}"
+    if [[ -z "${value}" ]]; then
+        printf 'host.containers.internal'
+        return 0
+    fi
+    case ",${value}," in
+        *,host.containers.internal,*) printf '%s' "${value}" ;;
+        *) printf '%s,host.containers.internal' "${value}" ;;
+    esac
+}
+
+host_http_proxy="$(sanitize_proxy "${raw_http_proxy}")"
+host_https_proxy="$(sanitize_proxy "${raw_https_proxy}")"
+host_no_proxy="$(augment_no_proxy "${raw_no_proxy}")"
+
+proxy_ca_hint="${repo_root}/cache/https-proxy-ca.pem"
+proxy_ca="${HTTPS_PROXY_CA:-}"
+if [[ -z "${proxy_ca}" && -f "${proxy_ca_hint}" ]]; then
+    proxy_ca="${proxy_ca_hint}"
+fi
+
+if [[ -n "${raw_https_proxy}" ]]; then
+    if [[ -z "${proxy_ca}" ]]; then
+        printf 'https_proxy=%s detected but no proxy CA found.\n' "${raw_https_proxy}" >&2
+        printf 'Run `just proxy-cert` to capture it into %s before proceeding.\n' "${proxy_ca_hint}" >&2
+        exit 1
+    fi
+    if [[ ! -f "${proxy_ca}" ]]; then
+        printf 'Proxy CA file not found at %s. Run `just proxy-cert` to refresh it.\n' "${proxy_ca}" >&2
+        exit 1
+    fi
+fi
+
+flags=()
+
+if [[ -n "${host_http_proxy}" ]]; then
+    flags+=(--env "http_proxy=${host_http_proxy}" --env "HTTP_PROXY=${host_http_proxy}")
+fi
+
+if [[ -n "${host_https_proxy}" ]]; then
+    flags+=(--env "https_proxy=${host_https_proxy}" --env "HTTPS_PROXY=${host_https_proxy}")
+fi
+
+if [[ -n "${host_no_proxy}" ]]; then
+    flags+=(--env "no_proxy=${host_no_proxy}" --env "NO_PROXY=${host_no_proxy}")
+fi
+
+if [[ -n "${proxy_ca}" ]]; then
+    proxy_ca_abs="$(cd "$(dirname "${proxy_ca}")" && pwd)/$(basename "${proxy_ca}")"
+    flags+=(--env "CURL_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem")
+    flags+=(--env "SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem")
+    flags+=(--env "REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem")
+    flags+=(--volume "${proxy_ca_abs}:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:ro,z")
+    flags+=(--volume "${proxy_ca_abs}:/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt:ro,z")
+fi
+
+if [[ "${#flags[@]}" -gt 0 ]]; then
+    printf '%s\n' "${flags[@]}"
+fi

--- a/scripts/proxy-cert.sh
+++ b/scripts/proxy-cert.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Extract the proxy-provided TLS certificate when https_proxy is configured.
+set -euo pipefail
+
+proxy_url="${https_proxy:-${HTTPS_PROXY:-}}"
+output_path="${1:-cache/https-proxy-ca.pem}"
+target_host="${PROXY_CERT_TARGET_HOST:-example.com}"
+target_port="${PROXY_CERT_TARGET_PORT:-443}"
+
+if [[ -z "${proxy_url}" ]]; then
+    printf 'https_proxy is not set; nothing to capture.\n' >&2
+    exit 1
+fi
+
+if ! command -v openssl >/dev/null 2>&1; then
+    printf 'openssl is required to capture the proxy certificate.\n' >&2
+    exit 1
+fi
+
+scheme="${proxy_url%%://*}"
+rest="${proxy_url#*://}"
+if [[ "${scheme}" == "${rest}" ]]; then
+    # No scheme detected; assume raw host[:port]
+    rest="${proxy_url}"
+fi
+
+# Strip credentials if present.
+if [[ "${rest}" == *"@"* ]]; then
+    rest="${rest#*@}"
+fi
+
+# Drop any trailing path component.
+rest="${rest%%/*}"
+
+proxy_host="${rest%%:*}"
+proxy_port="${rest##*:}"
+if [[ "${proxy_port}" == "${proxy_host}" ]]; then
+    if [[ "${scheme}" == "https" || "${scheme}" == "HTTPS" ]]; then
+        proxy_port="443"
+    else
+        proxy_port="3128"
+    fi
+fi
+
+if [[ -z "${proxy_host}" ]]; then
+    printf 'Unable to parse https_proxy="%s". Expected host[:port].\n' "${proxy_url}" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "${output_path}")"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+tmp_output="${tmp_dir}/s_client.out"
+
+printf 'Fetching proxy certificate via %s:%s -> %s:%s ...\n' "${proxy_host}" "${proxy_port}" "${target_host}" "${target_port}"
+if ! openssl s_client \
+        -proxy "${proxy_host}:${proxy_port}" \
+        -connect "${target_host}:${target_port}" \
+        -servername "${target_host}" \
+        -showcerts \
+        < /dev/null > "${tmp_output}" 2> "${tmp_dir}/s_client.err"; then
+    printf 'Failed to connect via proxy. Details:\n' >&2
+    cat "${tmp_dir}/s_client.err" >&2
+    exit 1
+fi
+
+certificate="$(awk '
+    /-----BEGIN CERTIFICATE-----/ { capture=1 }
+    capture { print }
+    /-----END CERTIFICATE-----/ { exit }
+' "${tmp_output}")"
+
+if [[ -z "${certificate}" ]]; then
+    printf 'No certificate block found in proxy response. See %s for raw output.\n' "${tmp_output}" >&2
+    exit 1
+fi
+
+printf '%s\n' "${certificate}" > "${output_path}"
+chmod 0644 "${output_path}"
+
+printf 'Wrote proxy CA to %s\n' "${output_path}"
+printf 'Mount this file into your podman builds at:\n' >&2
+printf '  /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem\n' >&2
+printf '  /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt\n' >&2


### PR DESCRIPTION
Introduce a proxy-cert helper to capture the proxy CA and a shared podman-proxy-flags.sh script so every podman build/run inherits proxy settings and mounts the captured certificate.